### PR TITLE
Export IovLedgerApp and friends for direct use

### DIFF
--- a/custom_types/ledgerhq__hw-transport-node-hid/index.d.ts
+++ b/custom_types/ledgerhq__hw-transport-node-hid/index.d.ts
@@ -1,5 +1,5 @@
 declare module "@ledgerhq/hw-transport-node-hid" {
-  import { Transport } from "@ledgerhq/hw-transport";
+  import Transport from "@ledgerhq/hw-transport";
   import { Device, HID } from "node-hid";
 
   /**

--- a/custom_types/ledgerhq__hw-transport/index.d.ts
+++ b/custom_types/ledgerhq__hw-transport/index.d.ts
@@ -14,4 +14,6 @@ declare module "@ledgerhq/hw-transport" {
       statusList?: number[],
     ): Promise<Buffer>;
   }
+
+  export default Transport;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,3 @@
 export { IovLedgerWallet } from "./iovledgerwallet";
+export { LedgerApp as IovLedgerApp } from "./ledgerapp";
+export { TransportHelpers } from "./transporthelpers";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,12 @@
 export { IovLedgerWallet } from "./iovledgerwallet";
-export { LedgerApp as IovLedgerApp } from "./ledgerapp";
+export {
+  LedgerApp as IovLedgerApp,
+  LedgerAppErrorState,
+  LedgerAppVersion,
+  isLedgerAppVersion,
+  LedgerAppAddress,
+  isLedgerAppAddress,
+  LedgerAppSignature,
+  isLedgerAppSignature,
+} from "./ledgerapp";
 export { TransportHelpers } from "./transporthelpers";

--- a/src/iovledgerwallet.ts
+++ b/src/iovledgerwallet.ts
@@ -23,8 +23,8 @@ import { DefaultValueProducer, ValueAndUpdates } from "@iov/stream";
 import PseudoRandom from "random-js";
 import { As } from "type-tagger";
 
-import { Communication } from "./communication";
 import { isLedgerAppAddress, isLedgerAppSignature, LedgerApp } from "./ledgerapp";
+import { TransportHelpers } from "./transporthelpers";
 
 interface PubkeySerialization {
   readonly algo: string;
@@ -240,7 +240,7 @@ export class IovLedgerWallet implements Wallet {
     }
 
     const accountIndex = this.getAccountIndex(identity);
-    const transport = await Communication.createTransport();
+    const transport = await TransportHelpers.createTransport();
     const app = new LedgerApp(transport);
     const signatureResponse = await app.sign(accountIndex, transactionBytes);
     await transport.close();
@@ -291,7 +291,7 @@ export class IovLedgerWallet implements Wallet {
     }
     const index = options;
 
-    const transport = await Communication.createTransport();
+    const transport = await TransportHelpers.createTransport();
     const app = new LedgerApp(transport);
     const addressResponse = await app.getAddress(index);
     await transport.close();

--- a/src/ledgerapp.spec.ts
+++ b/src/ledgerapp.spec.ts
@@ -2,7 +2,7 @@ import "babel-polyfill";
 
 import { Ed25519, Sha512 } from "@iov/crypto";
 import { Encoding } from "@iov/encoding";
-import { Transport } from "@ledgerhq/hw-transport";
+import Transport from "@ledgerhq/hw-transport";
 import TransportNodeHid from "@ledgerhq/hw-transport-node-hid";
 
 import { pendingWithoutInteractiveLedger, pendingWithoutSeededLedger, skipSeededTests } from "./common.spec";

--- a/src/ledgerapp.ts
+++ b/src/ledgerapp.ts
@@ -14,7 +14,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { Transport } from "@ledgerhq/hw-transport";
+import Transport from "@ledgerhq/hw-transport";
 
 const CLA = 0x22;
 const CHUNK_SIZE = 250;

--- a/src/transporthelpers.ts
+++ b/src/transporthelpers.ts
@@ -1,5 +1,4 @@
 import { Transport } from "@ledgerhq/hw-transport";
-import TransportNodeHid from "@ledgerhq/hw-transport-node-hid";
 
 function environmentIsNodeJs(): boolean {
   return (
@@ -12,6 +11,9 @@ function environmentIsNodeJs(): boolean {
 export class TransportHelpers {
   public static async createTransport(): Promise<Transport> {
     if (environmentIsNodeJs()) {
+      // This module must be imported dynamically in order to allow using @iov/ledger-bns in the browser
+      // tslint:disable-next-line: variable-name
+      const TransportNodeHid = (await import("@ledgerhq/hw-transport-node-hid")).default;
       return TransportNodeHid.create(1000);
     } else {
       throw new Error("No transport available for this environment");

--- a/src/transporthelpers.ts
+++ b/src/transporthelpers.ts
@@ -1,4 +1,4 @@
-import { Transport } from "@ledgerhq/hw-transport";
+import Transport from "@ledgerhq/hw-transport";
 
 function environmentIsNodeJs(): boolean {
   return (

--- a/src/transporthelpers.ts
+++ b/src/transporthelpers.ts
@@ -9,7 +9,7 @@ function environmentIsNodeJs(): boolean {
   );
 }
 
-export class Communication {
+export class TransportHelpers {
   public static async createTransport(): Promise<Transport> {
     if (environmentIsNodeJs()) {
       return TransportNodeHid.create(1000);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,1 +1,3 @@
 export { IovLedgerWallet } from "./iovledgerwallet";
+export { LedgerApp as IovLedgerApp } from "./ledgerapp";
+export { TransportHelpers } from "./transporthelpers";

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,3 +1,3 @@
 export { IovLedgerWallet } from "./iovledgerwallet";
-export { LedgerApp as IovLedgerApp } from "./ledgerapp";
+export { LedgerApp as IovLedgerApp, LedgerAppErrorState, LedgerAppVersion, isLedgerAppVersion, LedgerAppAddress, isLedgerAppAddress, LedgerAppSignature, isLedgerAppSignature, } from "./ledgerapp";
 export { TransportHelpers } from "./transporthelpers";

--- a/types/ledgerapp.d.ts
+++ b/types/ledgerapp.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="node" />
 /// <reference types="ledgerhq__hw-transport" />
-import { Transport } from "@ledgerhq/hw-transport";
+import Transport from "@ledgerhq/hw-transport";
 export interface LedgerAppErrorState {
     readonly returnCode: number;
     readonly errorMessage: string;

--- a/types/transporthelpers.d.ts
+++ b/types/transporthelpers.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="ledgerhq__hw-transport" />
 import { Transport } from "@ledgerhq/hw-transport";
-export declare class Communication {
+export declare class TransportHelpers {
     static createTransport(): Promise<Transport>;
 }

--- a/types/transporthelpers.d.ts
+++ b/types/transporthelpers.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="ledgerhq__hw-transport" />
-import { Transport } from "@ledgerhq/hw-transport";
+import Transport from "@ledgerhq/hw-transport";
 export declare class TransportHelpers {
     static createTransport(): Promise<Transport>;
 }


### PR DESCRIPTION
For many use cases it is a big overhead to go through the `IovLedgerWallet` implementation in order to interact with the app.

With the following changes, I can use the `LedgerApp` from a web project via WebUSB.