### PR TITLE
Convert version to semver compatible string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.14.0
+
+Breaking changes:
+
+- Convert `LedgerAppVersion.major`, `.minor`, `.patch` to `.version` string that
+  can be checked using semver.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "access": "public"
   },
   "scripts": {
+    "format-text": "prettier --write --prose-wrap always --print-width 80 \"./*.md\"",
     "docs": "shx rm -rf docs && typedoc --options typedoc.js",
     "lint": "eslint --max-warnings 0 \"**/*.{js,ts}\" && tslint -t verbose --project .",
     "lint-fix": "eslint --max-warnings 0 \"**/*.{js,ts}\" --fix",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@types/jasmine": "^3.3.7",
+    "@types/semver": "^6.0.1",
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
     "eslint": "^6.1.0",
@@ -56,6 +57,7 @@
     "jasmine": "^3.3.1",
     "jasmine-spec-reporter": "^4.2.1",
     "prettier": "^1.18.2",
+    "semver": "^6.3.0",
     "shx": "^0.3.2",
     "source-map-support": "^0.5.13",
     "tslint": "^5.18.0",

--- a/src/ledgerapp.spec.ts
+++ b/src/ledgerapp.spec.ts
@@ -5,7 +5,12 @@ import { Encoding } from "@iov/encoding";
 import Transport from "@ledgerhq/hw-transport";
 import TransportNodeHid from "@ledgerhq/hw-transport-node-hid";
 
-import { pendingWithoutInteractiveLedger, pendingWithoutSeededLedger, skipSeededTests } from "./common.spec";
+import {
+  pendingWithoutInteractiveLedger,
+  pendingWithoutLedger,
+  pendingWithoutSeededLedger,
+  skipTests,
+} from "./common.spec";
 import { isLedgerAppAddress, isLedgerAppSignature, isLedgerAppVersion, LedgerApp } from "./ledgerapp";
 
 const { fromHex } = Encoding;
@@ -14,7 +19,7 @@ describe("LedgerApp", () => {
   let transport: Transport | undefined;
 
   beforeAll(async () => {
-    if (!skipSeededTests()) {
+    if (!skipTests()) {
       transport = await TransportNodeHid.create(1000);
     }
   });
@@ -50,7 +55,7 @@ describe("LedgerApp", () => {
 
   describe("getVersion", () => {
     it("works", async () => {
-      pendingWithoutSeededLedger();
+      pendingWithoutLedger();
 
       const app = new LedgerApp(transport!);
       const version = await app.getVersion();

--- a/src/ledgerapp.spec.ts
+++ b/src/ledgerapp.spec.ts
@@ -4,6 +4,7 @@ import { Ed25519, Sha512 } from "@iov/crypto";
 import { Encoding } from "@iov/encoding";
 import Transport from "@ledgerhq/hw-transport";
 import TransportNodeHid from "@ledgerhq/hw-transport-node-hid";
+import * as semver from "semver";
 
 import {
   pendingWithoutInteractiveLedger,
@@ -58,17 +59,16 @@ describe("LedgerApp", () => {
       pendingWithoutLedger();
 
       const app = new LedgerApp(transport!);
-      const version = await app.getVersion();
-      if (!isLedgerAppVersion(version)) throw new Error(version.errorMessage);
-      expect(version).toEqual(
+      const response = await app.getVersion();
+      if (!isLedgerAppVersion(response)) throw new Error(response.errorMessage);
+      expect(response).toEqual(
         jasmine.objectContaining({
-          major: 0,
-          minor: 8,
-          patch: 0,
           deviceLocked: false,
           errorMessage: "No errors",
         }),
       );
+      expect(response.version).toMatch(/^[0-9]+\.[0-9]+\.[0-9]+$/);
+      expect(semver.satisfies(response.version, "^0.8.0 || ^0.9.0")).toEqual(true);
     });
   });
 

--- a/src/ledgerapp.ts
+++ b/src/ledgerapp.ts
@@ -70,18 +70,14 @@ export interface LedgerAppErrorState {
 
 export interface LedgerAppVersion extends LedgerAppErrorState {
   readonly testMode: boolean;
-  readonly major: number;
-  readonly minor: number;
-  readonly patch: number;
+  readonly version: string;
   readonly deviceLocked: boolean;
 }
 
 export function isLedgerAppVersion(data: LedgerAppVersion | LedgerAppErrorState): data is LedgerAppVersion {
   return (
     typeof (data as LedgerAppVersion).testMode !== "undefined" &&
-    typeof (data as LedgerAppVersion).major !== "undefined" &&
-    typeof (data as LedgerAppVersion).minor !== "undefined" &&
-    typeof (data as LedgerAppVersion).patch !== "undefined" &&
+    typeof (data as LedgerAppVersion).version === "string" &&
     typeof (data as LedgerAppVersion).deviceLocked !== "undefined"
   );
 }
@@ -171,15 +167,14 @@ export class LedgerApp {
       const errorCodeData = response.slice(-2);
       const errorCode = errorCodeData[0] * 256 + errorCodeData[1];
 
-      return {
+      const success: LedgerAppVersion = {
         testMode: response[0] !== 0,
-        major: response[1],
-        minor: response[2],
-        patch: response[3],
+        version: `${response[1]}.${response[2]}.${response[3]}`,
         deviceLocked: response[4] === 1,
         returnCode: errorCode,
         errorMessage: errorCodeToString(errorCode),
       };
+      return success;
     }, LedgerApp.processErrorResponse);
   }
 

--- a/types/ledgerapp.d.ts
+++ b/types/ledgerapp.d.ts
@@ -7,9 +7,7 @@ export interface LedgerAppErrorState {
 }
 export interface LedgerAppVersion extends LedgerAppErrorState {
     readonly testMode: boolean;
-    readonly major: number;
-    readonly minor: number;
-    readonly patch: number;
+    readonly version: string;
     readonly deviceLocked: boolean;
 }
 export declare function isLedgerAppVersion(data: LedgerAppVersion | LedgerAppErrorState): data is LedgerAppVersion;

--- a/yarn.lock
+++ b/yarn.lock
@@ -346,6 +346,11 @@
   resolved "https://registry.yarnpkg.com/@types/random-js/-/random-js-1.0.31.tgz#18a8bcc075afa504421e638fcbe021f27e802941"
   integrity sha512-EAM56DrKw3VhcE4HV0/YlVKeJI07We4Mz1ra6TNtZpaMoiBVMA2bkLEcoFpYOyxoDXfVZWojxkR617LTqtRI0A==
 
+"@types/semver@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-6.0.1.tgz#a984b405c702fa5a7ec6abc56b37f2ba35ef5af6"
+  integrity sha512-ffCdcrEE5h8DqVxinQjo+2d1q+FV5z7iNtPofw3JsrltSoSVlOGaW0rY8XxtO9XukdTn8TaCGWmk2VFGhI70mg==
+
 "@types/shelljs@^0.8.0":
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.8.5.tgz#1e507b2f6d1f893269bd3e851ec24419ef9beeea"
@@ -1855,7 +1860,7 @@ semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@^6.1.2, semver@^6.2.0:
+semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==


### PR DESCRIPTION
and allow "^0.8.0 || ^0.9.0" in tests.

This also gets handy when an application requires a minimal version of the app to work or wants to display security warnings for certain ranges.